### PR TITLE
Allow empty tasks that just run others

### DIFF
--- a/spokfile
+++ b/spokfile
@@ -48,6 +48,9 @@ task lint(fmt, "**/*.go") {
     golangci-lint run --fix
 }
 
+# Run tests and linting
+task check(test, lint, "**/*.go") {}
+
 # Calculate test coverage and render the html
 task cover("**/*.go") -> (COVERAGE_DATA, COVERAGE_HTML) {
     SPOK_INTEGRATION_TEST=true go test -race -cover -covermode=atomic -coverprofile={{.COVERAGE_DATA}} ./...

--- a/task/task.go
+++ b/task/task.go
@@ -29,14 +29,11 @@ type Task struct {
 	GlobOutputs      []string // Filepaths this task outputs that are specified as glob patterns
 }
 
-// Run runs a task commands in order, echoing each one to out and
-// returning the list of results containing the exit status,
-// stdout and stderr of each command.
+// Run runs a task commands in order, echoing each one to out and returning the list of results
+// containing the exit status, stdout and stderr of each command.
+//
+// If the task has no commands, this becomes a no-op.
 func (t *Task) Run(runner shell.Runner, stream iostream.IOStream, env []string) (shell.Results, error) {
-	if len(t.Commands) == 0 {
-		return nil, fmt.Errorf("Task %q has no commands", t.Name)
-	}
-
 	echoStyle := color.New(color.FgHiWhite, color.Bold)
 
 	var results shell.Results

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -382,7 +382,7 @@ func TestTaskRun(t *testing.T) {
 			name:    "empty",
 			task:    Task{Name: "empty"},
 			want:    nil,
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "simple",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
It is now possible to declare a task with no commands which is useful in the following example:

```plain
task test("**/*.go") {
    go test ./...
}

task lint("**/*.go") {
    golangci-lint run
}

# Do nothing itself, but run test and lint
task check(test, lint) {}
```

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if needed.
- [ ] I have updated the tests if needed.
